### PR TITLE
Fix: Fixed api calls on build production

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -11,7 +11,17 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     output: "static",
     favicon: "./assets/favicon.png",
   },
-  plugins: ["expo-router"],
+  plugins: [
+    "expo-router",
+    [
+      "expo-build-properties",
+      {
+        android: {
+          usesCleartextTraffic: true,
+        },
+      },
+    ],
+  ],
   experiments: {
     typedRoutes: true,
     tsconfigPaths: true,
@@ -45,5 +55,6 @@ export default ({ config }: ConfigContext): ExpoConfig => ({
     // Variáveis de ambiente disponíveis no app
     appEnv: process.env.APP_ENV || "development",
     apiUrl: process.env.API_URL,
+    apiPort: process.env.API_PORT,
   },
 });

--- a/eas.json
+++ b/eas.json
@@ -1,10 +1,15 @@
 {
   "cli": {
-    "requireCommit": false
+    "requireCommit": false,
+    "appVersionSource": "remote"
   },
   "build": {
     "production": {
       "node": "22.12.0",
+      "autoIncrement": true,
+      "android": {
+        "buildType": "apk"
+      },
       "env": {
         "APP_ENV": "production"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@reduxjs/toolkit": "^2.6.1",
         "axios": "^1.9.0",
         "expo": "^54.0.30",
+        "expo-build-properties": "~1.0.10",
         "expo-constants": "~18.0.12",
         "expo-linking": "~8.0.11",
         "expo-router": "~6.0.21",
@@ -7946,6 +7947,53 @@
         "react-native": "*"
       }
     },
+    "node_modules/expo-build-properties": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/expo-build-properties/-/expo-build-properties-1.0.10.tgz",
+      "integrity": "sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ajv": "^8.11.0",
+        "semver": "^7.6.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/ajv": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
+      "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/expo-build-properties/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT"
+    },
+    "node_modules/expo-build-properties/node_modules/semver": {
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/expo-constants": {
       "version": "18.0.12",
       "resolved": "https://registry.npmjs.org/expo-constants/-/expo-constants-18.0.12.tgz",
@@ -8389,6 +8437,22 @@
       "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
+      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-xml-parser": {
       "version": "4.5.3",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@reduxjs/toolkit": "^2.6.1",
     "axios": "^1.9.0",
     "expo": "^54.0.30",
+    "expo-build-properties": "~1.0.10",
     "expo-constants": "~18.0.12",
     "expo-linking": "~8.0.11",
     "expo-router": "~6.0.21",

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -19,7 +19,6 @@ import { useModalConfirmation } from "~/contexts/DialogContext";
 import { setInfoToast } from "~/store/reducers/geral";
 import { IListPurchaseView } from "~/types/listPurchase";
 import { formatMonetary } from "~/utils/stringUtils";
-import { calculateValuesByMeasuredUnits } from "~/utils/sumUtils";
 
 type IDialog = {
   open: boolean;

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -39,7 +39,7 @@ export async function remove(endpoint: string): Promise<any> {
 function getUrlBase(): string {
   // Usa a URL definida nas variáveis de ambiente
   const apiUrl = Constants.expoConfig?.extra?.apiUrl;
-  
+
   // Produção - usa a URL do ambiente
   if (!__DEV__ || apiUrl) {
     if (!apiUrl) {
@@ -53,11 +53,11 @@ function getUrlBase(): string {
 
   if (debuggerHost) {
     // Usa o IP detectado pelo Expo (funciona em dispositivos físicos e emuladores)
-    return `http://${debuggerHost}:21200/`;
+    return `http://${debuggerHost}:${Constants.expoConfig?.extra?.apiPort}`;
   }
 
   // Fallback para emulador Android
-  return "http://10.0.2.2:21200/";
+  return `http://10.0.2.2:${Constants.expoConfig?.extra?.apiPort}`;
 }
 
 function getHeaders(): Record<string, string> {


### PR DESCRIPTION
This pull request introduces several configuration improvements and enhancements to the build and environment setup for the Expo app. The most notable updates include enabling cleartext traffic for Android builds, making the API port configurable via environment variables, automating version and build settings, and adding the `expo-build-properties` plugin.

**Build and configuration enhancements:**

* Added the `expo-build-properties` plugin to `app.config.ts` and enabled cleartext traffic for Android, which is necessary for development environments that require HTTP connections. [[1]](diffhunk://#diff-d51482575c05bfaf700fbd0aff44160e591fc99b684beac4aef55d208a24f42eL14-R24) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R26)
* Updated `eas.json` to automate versioning (`autoIncrement: true`), set the app version source to remote, and specify APK build type for Android production builds.

**Environment variable improvements:**

* Made the API port configurable by adding `apiPort` to the `extra` config in `app.config.ts` and updating the API base URL logic in `src/services/api.ts` to use this environment variable. [[1]](diffhunk://#diff-d51482575c05bfaf700fbd0aff44160e591fc99b684beac4aef55d208a24f42eR58) [[2]](diffhunk://#diff-0e184ea1c8a349adddc149579c2624e138ff629253721c460c28db1a33119533L56-R60)

**Code cleanup:**
